### PR TITLE
sepolicy: allow nfc service "find" access to system server

### DIFF
--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -3,6 +3,9 @@
 allow platform_app sdcard_posix:dir create_dir_perms;
 allow platform_app sdcard_posix:file create_file_perms;
 
+# Allow NFC service to find access to system server
+allow platform_app nfc_service:service_manager find;
+
 # Allow batterymanager and batteryproperties services to be found
 allow platform_app battery_service:service_manager find;
 allow platform_app healthd_service:service_manager find;


### PR DESCRIPTION
  * Fixs a denial when querying if nfc service is active on device
      to allow nfc quick settings tile to be added

Change-Id: I2323b9eb384741c30cf93a17128a771941342aa1